### PR TITLE
Favorites done

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
         <!--LINK CUSTOM CSS FILE-->
         <link rel="stylesheet" href="style.css">
         <!--FONTAWESOME CDN-->
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css" 
-        integrity="sha512-+4zCK9k+qNFUR5X+cKL9EIR+ZOhtIloNl9GIKS57V1MyNsYpYcUrUeQc9vNfzsWfV28IaLL3i96P9sdNyeRssA==" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" 
+        integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" 
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
     </head>
     <body>
         <div class="container">
@@ -22,12 +23,24 @@
             <i class="fas fa-quote-right"></i>
             </h1>
             <p class="author" id="author"></p>
+            <a href=""><i id="heart" class="fa-regular fa-heart fa-beat"></i></a>
+            <a href=""><i id="fullHeart" class="fa-solid fa-heart fa-beat"></i></a>
             <hr/>
             <div class="buttons">
                 <a class="twitter" id="tweet" data-size="large" target="_blank" rel="noopener noreferrer"><i class="fab fa-twitter"></i></a>
+                <button class="next" id="favBtn">Open favorites</button>
                 <button class="next" id="next2">Next quote</button>
             </div>
         </div>
+        <!--Modal Window-->
+        <div id="favoritesModal" class="modal">
+            <div class="modal-content">
+                <span class="close">&times;</span>
+                <h2>Favorite Quotes</h2>
+                <div id="favoriteQuotesList"></div>
+            </div>
+        </div>
+        
         
         <script type="module" src="js/main.js"></script>
     </body>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
                 <span class="close">&times;</span>
                 <h2>Favorite Quotes</h2>
                 <div id="favoriteQuotesList"></div>
+                <button id="clearFavorites" class="clear-btn">Clear All Favorites</button>
             </div>
         </div>
         

--- a/js/events.js
+++ b/js/events.js
@@ -1,8 +1,12 @@
 import { fetchQuotes } from './api.js'
 import { displayQuote } from './interface.js';
+import { saveFavoriteQuote, removeFavoriteQuote, showFavoriteQuotes } from './storage.js';
 
 export const initEventListeners = () => {
     const nextBtn = document.getElementById('next2');
+    const heartBtn = document.getElementById('heart');
+    const fullHeartBtn = document.getElementById('fullHeart');
+    const favBtn = document.getElementById('favBtn');
 
     // Asinhrona metoda za dobijanje novog citata
     const getNewQuote = async () => {
@@ -21,10 +25,52 @@ export const initEventListeners = () => {
         }
 
         displayQuote(quote, author);
+        
+        // Reset srca
+        heartBtn.style.display = 'inline-block';
+        fullHeartBtn.style.display = 'none';
     };
 
     // Poziv asinhrone metode getNewQuote klikom na dugme
     nextBtn.addEventListener('click', getNewQuote);
 
     getNewQuote()
+
+    // Logika za puno-prazno srce i cuvanje u localStorage
+    heartBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        heartBtn.style.display = 'none';
+        fullHeartBtn.style.display = 'inline-block';
+        const quote = document.getElementById('quote').innerText;
+        const author = document.getElementById('author').innerText;
+        saveFavoriteQuote(quote, author);
+    });
+    fullHeartBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        heartBtn.style.display = 'inline-block';
+        fullHeartBtn.style.display = 'none';
+        const quote = document.getElementById('quote').innerText;
+        const author = document.getElementById('author').innerText;
+        removeFavoriteQuote(quote, author);
+    });
+    favBtn.addEventListener('click', showFavoriteQuotes);
 };
+    // Listener za prikaz omiljenih citata
+    favBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        showFavoriteQuotes();
+        document.getElementById('favoritesModal').style.display = 'block';
+    })
+    // Listener za zatvaranje modala
+    const closeModalBtn = document.querySelector('.close');
+    closeModalBtn.addEventListener('click', () => {
+    document.getElementById('favoritesModal').style.display = 'none';
+});
+    // Listener za zatvaranje modala klikom izvan sadrzaja
+    window.addEventListener('click', (event) => {
+    const modal = document.getElementById('favoritesModal');
+    if (event.target === modal) {
+        modal.style.display = 'none';
+    }
+});
+

--- a/js/events.js
+++ b/js/events.js
@@ -1,6 +1,6 @@
 import { fetchQuotes } from './api.js'
 import { displayQuote } from './interface.js';
-import { saveFavoriteQuote, removeFavoriteQuote, showFavoriteQuotes, isFavorite, clearAllFavorites} from './storage.js';
+import { saveFavoriteQuote, removeFavoriteQuote, showFavoriteQuotes, isFavorite, clearAllFavorites } from './storage.js';
 
 export const initEventListeners = () => {
     const nextBtn = document.getElementById('next2');
@@ -16,8 +16,8 @@ export const initEventListeners = () => {
         let author = allQuotes[index].author;
 
         if (author) {
-            author = author.split(',')[0]; // Uzimam samo ime pre zareza
-            if (author.trim().toLowerCase() === "type.fit") {
+            author = author.replace(', type.fit', ''); // Uklanja ", type.fit" iz imena
+            if (author.trim().toLowerCase() === "type.fit" || author.trim() === "") {
                 author = "Anonymous";
             }
         } else {
@@ -25,9 +25,9 @@ export const initEventListeners = () => {
         }
 
         displayQuote(quote, author);
-        
+
         // Provera da li je citat dodat u 'omiljeno'
-        if (isFavorite(quote, author)) {
+        if (isFavorite(quote)) {
             heartBtn.style.display = 'none';
             fullHeartBtn.style.display = 'inline-block';
         } else {
@@ -39,7 +39,7 @@ export const initEventListeners = () => {
     // Poziv asinhrone metode getNewQuote klikom na dugme
     nextBtn.addEventListener('click', getNewQuote);
 
-    getNewQuote()
+    getNewQuote();
 
     // Logika za puno-prazno srce i cuvanje u localStorage
     heartBtn.addEventListener('click', (e) => {
@@ -47,42 +47,42 @@ export const initEventListeners = () => {
         heartBtn.style.display = 'none';
         fullHeartBtn.style.display = 'inline-block';
         const quote = document.getElementById('quote').innerText;
-        const author = document.getElementById('author').innerText;
-        saveFavoriteQuote(quote, author);
+        saveFavoriteQuote(quote);
     });
     fullHeartBtn.addEventListener('click', (e) => {
         e.preventDefault();
         heartBtn.style.display = 'inline-block';
         fullHeartBtn.style.display = 'none';
         const quote = document.getElementById('quote').innerText;
-        const author = document.getElementById('author').innerText;
-        removeFavoriteQuote(quote, author);
+        removeFavoriteQuote(quote);
     });
     favBtn.addEventListener('click', showFavoriteQuotes);
 };
-    // Listener za prikaz omiljenih citata
-    favBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        showFavoriteQuotes();
-        document.getElementById('favoritesModal').style.display = 'block';
-    })
 
-    const clearFavoritesBtn = document.getElementById('clearFavorites');
-    // Brisanje svih omiljenih
-    clearFavoritesBtn.addEventListener('click', () => {
-        clearAllFavorites();
-        showFavoriteQuotes();
-    });
-    // Listener za zatvaranje modala
-    const closeModalBtn = document.querySelector('.close');
-    closeModalBtn.addEventListener('click', () => {
+// Listener za prikaz omiljenih citata
+favBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    showFavoriteQuotes();
+    document.getElementById('favoritesModal').style.display = 'block';
+});
+
+const clearFavoritesBtn = document.getElementById('clearFavorites');
+// Brisanje svih omiljenih
+clearFavoritesBtn.addEventListener('click', () => {
+    clearAllFavorites();
+    showFavoriteQuotes();
+});
+
+// Listener za zatvaranje modala
+const closeModalBtn = document.querySelector('.close');
+closeModalBtn.addEventListener('click', () => {
     document.getElementById('favoritesModal').style.display = 'none';
 });
-    // Listener za zatvaranje modala klikom izvan sadrzaja
-    window.addEventListener('click', (event) => {
+
+// Listener za zatvaranje modala klikom izvan sadrzaja
+window.addEventListener('click', (event) => {
     const modal = document.getElementById('favoritesModal');
     if (event.target === modal) {
         modal.style.display = 'none';
     }
 });
-

--- a/js/events.js
+++ b/js/events.js
@@ -1,6 +1,6 @@
 import { fetchQuotes } from './api.js'
 import { displayQuote } from './interface.js';
-import { saveFavoriteQuote, removeFavoriteQuote, showFavoriteQuotes } from './storage.js';
+import { saveFavoriteQuote, removeFavoriteQuote, showFavoriteQuotes, isFavorite, clearAllFavorites} from './storage.js';
 
 export const initEventListeners = () => {
     const nextBtn = document.getElementById('next2');
@@ -26,9 +26,14 @@ export const initEventListeners = () => {
 
         displayQuote(quote, author);
         
-        // Reset srca
-        heartBtn.style.display = 'inline-block';
-        fullHeartBtn.style.display = 'none';
+        // Provera da li je citat dodat u 'omiljeno'
+        if (isFavorite(quote, author)) {
+            heartBtn.style.display = 'none';
+            fullHeartBtn.style.display = 'inline-block';
+        } else {
+            heartBtn.style.display = 'inline-block';
+            fullHeartBtn.style.display = 'none';
+        }
     };
 
     // Poziv asinhrone metode getNewQuote klikom na dugme
@@ -61,6 +66,13 @@ export const initEventListeners = () => {
         showFavoriteQuotes();
         document.getElementById('favoritesModal').style.display = 'block';
     })
+
+    const clearFavoritesBtn = document.getElementById('clearFavorites');
+    // Brisanje svih omiljenih
+    clearFavoritesBtn.addEventListener('click', () => {
+        clearAllFavorites();
+        showFavoriteQuotes();
+    });
     // Listener za zatvaranje modala
     const closeModalBtn = document.querySelector('.close');
     closeModalBtn.addEventListener('click', () => {

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,24 +1,27 @@
 // Cuvanje novog citata u localStorage
-export const saveFavoriteQuote = (quote, author) => {
+export const saveFavoriteQuote = (quote) => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
-    // Provera da li vec postoji u omiljenim
-    const alreadyFavorite = favorites.some(fav => fav.quote === quote && fav.author === author);
+    // Provera da li već postoji u omiljenim
+    const alreadyFavorite = favorites.some(fav => fav.quote === quote);
     if (!alreadyFavorite) {
-        favorites.push({ quote, author });
+        favorites.push({ quote });
         localStorage.setItem('favorites', JSON.stringify(favorites));
     }
 };
+
 // Uklanjanje omiljenog citata iz localStorage
-export const removeFavoriteQuote = (quote, author) => {
+export const removeFavoriteQuote = (quote) => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
-    favorites = favorites.filter(fav => fav.quote !== quote || fav.author !== author);
+    favorites = favorites.filter(fav => fav.quote !== quote);
     localStorage.setItem('favorites', JSON.stringify(favorites));
 };
+
 // Provera da li je citat stavljen u 'omiljeno'
-export const isFavorite = (quote, author) => {
+export const isFavorite = (quote) => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
-    return favorites.some(fav => fav.quote === quote && fav.author === author);
+    return favorites.some(fav => fav.quote === quote);
 };
+
 // Prikazivanje omiljenih citata
 export const showFavoriteQuotes = () => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
@@ -28,10 +31,11 @@ export const showFavoriteQuotes = () => {
     favorites.forEach(fav => {
         const quoteDiv = document.createElement('div');
         quoteDiv.classList.add('favorite-quote');
-        quoteDiv.innerHTML = `<p>${fav.quote}</p><p>${fav.author}</p>`;
+        quoteDiv.innerHTML = `<p>${fav.quote}</p>`;
         favoriteQuoteList.appendChild(quoteDiv);
-    })
+    });
 };
+
 // Funkcija za brisanje svih omiljenih citata iz localStorage
 export const clearAllFavorites = () => {
     localStorage.removeItem('favorites');

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,14 +1,23 @@
 // Cuvanje novog citata u localStorage
 export const saveFavoriteQuote = (quote, author) => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
-    favorites.push({ quote, author });
-    localStorage.setItem('favorites', JSON.stringify(favorites));
+    // Provera da li vec postoji u omiljenim
+    const alreadyFavorite = favorites.some(fav => fav.quote === quote && fav.author === author);
+    if (!alreadyFavorite) {
+        favorites.push({ quote, author });
+        localStorage.setItem('favorites', JSON.stringify(favorites));
+    }
 };
 // Uklanjanje omiljenog citata iz localStorage
 export const removeFavoriteQuote = (quote, author) => {
     let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
     favorites = favorites.filter(fav => fav.quote !== quote || fav.author !== author);
     localStorage.setItem('favorites', JSON.stringify(favorites));
+};
+// Provera da li je citat stavljen u 'omiljeno'
+export const isFavorite = (quote, author) => {
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+    return favorites.some(fav => fav.quote === quote && fav.author === author);
 };
 // Prikazivanje omiljenih citata
 export const showFavoriteQuotes = () => {
@@ -19,7 +28,11 @@ export const showFavoriteQuotes = () => {
     favorites.forEach(fav => {
         const quoteDiv = document.createElement('div');
         quoteDiv.classList.add('favorite-quote');
-        quoteDiv.innerHTML = `<p>${fav.quote}</p><p>~ ${fav.author}</p>`;
+        quoteDiv.innerHTML = `<p>${fav.quote}</p><p>${fav.author}</p>`;
         favoriteQuoteList.appendChild(quoteDiv);
     })
+};
+// Funkcija za brisanje svih omiljenih citata iz localStorage
+export const clearAllFavorites = () => {
+    localStorage.removeItem('favorites');
 };

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,25 @@
+// Cuvanje novog citata u localStorage
+export const saveFavoriteQuote = (quote, author) => {
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+    favorites.push({ quote, author });
+    localStorage.setItem('favorites', JSON.stringify(favorites));
+};
+// Uklanjanje omiljenog citata iz localStorage
+export const removeFavoriteQuote = (quote, author) => {
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+    favorites = favorites.filter(fav => fav.quote !== quote || fav.author !== author);
+    localStorage.setItem('favorites', JSON.stringify(favorites));
+};
+// Prikazivanje omiljenih citata
+export const showFavoriteQuotes = () => {
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+    const favoriteQuoteList = document.getElementById('favoriteQuotesList');
+    favoriteQuoteList.innerHTML = '';
+
+    favorites.forEach(fav => {
+        const quoteDiv = document.createElement('div');
+        quoteDiv.classList.add('favorite-quote');
+        quoteDiv.innerHTML = `<p>${fav.quote}</p><p>~ ${fav.author}</p>`;
+        favoriteQuoteList.appendChild(quoteDiv);
+    })
+};

--- a/style.css
+++ b/style.css
@@ -86,3 +86,59 @@ hr {
 {
     box-shadow: 0 10px 10px rgb(230, 0, 0);
 }
+
+/* Like btn  */
+#heart {
+    font-size: xx-large;
+    color: black;
+}
+#fullHeart {
+ font-size: xx-large;
+}
+/* Favorite btn */
+#favBtn {
+    margin-left: 10%;
+}
+/* Modal window */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 600px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    animation: fadeIn 0.4s;
+}
+
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+@keyframes fadeIn {
+    from {opacity: 0;}
+    to {opacity: 1;}
+}

--- a/style.css
+++ b/style.css
@@ -94,6 +94,7 @@ hr {
 }
 #fullHeart {
  font-size: xx-large;
+ color: black;
 }
 /* Favorite btn */
 #favBtn {
@@ -142,3 +143,17 @@ hr {
     from {opacity: 0;}
     to {opacity: 1;}
 }
+/* Clear All Favorites dugme */
+.clear-btn {
+    background-color: red;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-top: 20px;
+}
+.clear-btn:hover {
+    background-color: darkred;
+}
+


### PR DESCRIPTION
Checking quotes without authors: We modified the logic so that the check for favorite quotes is based only on the quote itself, regardless of the author. This has prevented formatting issues with authors that were causing errors.

Removing author checks: We removed the author check from the functions saveFavoriteQuote, removeFavoriteQuote, and isFavorite in storage.js.

Checking favorite quotes: The isFavorite function now checks if a quote is favored based solely on the quote.

Display of hearts: Displaying an empty or full heart now depends only on the quote, enabling the correct display of the heart's state.

The final version of the application functions correctly because it is simpler and focuses only on the quote as the key element for checking favorite quotes.